### PR TITLE
Fix empty user agent crash

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -396,9 +396,11 @@ class Prerender {
   _createHeaders() {
     let h = {
       "User-Agent": "prerender-cloud-nodejs-middleware",
-      "X-Original-User-Agent": this.req.headers["user-agent"],
       "accept-encoding": "gzip"
     };
+    
+    if (this.req.headers["user-agent"])
+      Object.assign(h, { "X-Original-User-Agent": this.req.headers["user-agent"] });
 
     let token = options.options.prerenderToken || process.env.PRERENDER_TOKEN;
 


### PR DESCRIPTION
Only set 'X-Original-User-Agent' if the request has a user agent
Alternatively, it could be set to 'not found' or 'undefined' if something depends on this header, see [this commit](https://github.com/GeKorm/prerendercloud-nodejs/commit/861c7242a70a2b1e1966ed6fa8653ed6c1dc0b7c#diff-c60c67bd505d9618ebf77a7f130903d0)