### PR TITLE
Change API URL to headless-render-api.com

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "prerendercloud",
-  "version": "1.45.4",
+  "version": "1.45.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -409,9 +409,9 @@
       }
     },
     "got-lite": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/got-lite/-/got-lite-8.0.1.tgz",
-      "integrity": "sha512-XMRuTVTiQzkPrjsDu+1GF/SoYusUdPXjRTuuiGBX2mqE4djU4aW9ea7E7p6kosCFNvLYW5bHmVvYT7J7WEmplQ==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/got-lite/-/got-lite-8.0.4.tgz",
+      "integrity": "sha512-a1DfXCyXKIfGzkcluPHVz0tBOHUiFIL793WCJhFtoizPn+qokcTqAaa3XFqYiPVg/7Efm/ZcRJcwtF1jaF0AlA==",
       "requires": {
         "@sindresorhus/is": "^0.6.0",
         "decompress-response": "^3.3.0",
@@ -426,7 +426,7 @@
         "p-timeout": "^1.2.0",
         "pify": "^3.0.0",
         "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
+        "timed-out": "^5.0.0",
         "url-parse-lax": "^3.0.0",
         "url-to-options": "^1.0.1"
       }
@@ -947,9 +947,9 @@
       }
     },
     "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-5.0.0.tgz",
+      "integrity": "sha512-+IAmaDqYnVi/HOMCeH4NDzdjTH9EHTC8xbe+PgXMKtovdMjbu25qYxeUj6u/yukMp1wDOhPeh6oTcIVepm5n7Q=="
     },
     "toidentifier": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "prerendercloud",
-  "version": "1.45.5",
-  "description": "Express middleware for prerendering javascript-rendered pages with https://www.prerender.cloud/ for SEO and open graph tags",
+  "version": "1.45.6",
+  "description": "Express middleware for pre-rendering JavaScript single page apps with https://headless-render-api.com (formerly prerender.cloud from 2016 - 2022) for SEO and open graph tags",
   "main": "./distribution/index.js",
   "scripts": {
     "build": "rm -rf distribution && mkdir distribution && cp -r source/* distribution/",
     "test": "jasmine"
   },
-  "author": "Jonathan Otto <support@prerender.cloud> (https://www.prerender.cloud/)",
+  "author": "Jonathan Otto <support@headless-render-api.com> (https://headless-render-api.com/)",
   "license": "MIT",
   "dependencies": {
     "debug": "^4.3.4",

--- a/source/index.js
+++ b/source/index.js
@@ -104,7 +104,7 @@ const userAgentIsBotFromList = (botsOnlyList, headers, requestedPath = "") => {
 const getServiceUrl = (hardcoded) =>
   (hardcoded && hardcoded.replace(/\/+$/, "")) ||
   process.env.PRERENDER_SERVICE_URL ||
-  "https://service.prerender.cloud";
+  "https://service.headless-render-api.com";
 const getRenderUrl = (action, url) =>
   [getServiceUrl(), action, url].filter((p) => p).join("/");
 


### PR DESCRIPTION
Prerender.cloud is being rebranded to headless-render-api.com but the legacy API URL service.prerender.cloud will continue to work in perpetuity.