### PR TITLE
Add shouldPrerenderAdditionalCheck, Improve UX for 400 errs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The pre-render/server-side rendering functionality of this package (as opposed t
     - [blacklistPaths](#blacklistpaths)
     - [whitelistPaths](#whitelistpaths)
     - [shouldPrerender](#shouldprerender)
+    - [shouldPrerenderAdditionalCheck](#shouldPrerenderAdditionalCheck)
   - [Caching](#caching)
     - [Disable Headless-Render-API.com server cache](#disable-headless-render-apicom-server-cache)
     - [Using the \(optional\) middleware cache](#using-the-optional-middleware-cache)
@@ -411,6 +412,27 @@ const prerendercloud = require("prerendercloud");
 prerendercloud.set("shouldPrerender", (req) => {
   return req.headers["user-agent"] === "googlebot" && someStateOnMyServer();
   // return bool
+});
+```
+
+<a name="shouldprerenderadditionalcheck"></a>
+<a id="shouldprerenderadditionalcheck"></a>
+
+#### shouldPrerenderAdditionalCheck
+
+Runs **in addition** to the default user-agent check. Useful if you have your own conditions.
+
+```javascript
+// time delay
+const waitUntil = new Date() + 10000;
+prerendercloud.set("shouldPrerenderAdditionalCheck", (req) => {
+  return new Date() > waitUntil;
+});
+
+// enable flag
+let isEnabled = false;
+prerendercloud.set("shouldPrerenderAdditionalCheck", (req) => {
+  return isEnabled;
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerendercloud",
-  "version": "1.46.1",
+  "version": "1.46.2",
   "description": "Express middleware for pre-rendering JavaScript single page apps with https://headless-render-api.com (formerly prerender.cloud from 2016 - 2022) for SEO and open graph tags",
   "main": "./distribution/index.js",
   "scripts": {

--- a/source/index.js
+++ b/source/index.js
@@ -379,10 +379,10 @@ class Prerender {
 
     try {
       if (data.statusCode === 400) {
-        res.statusCode = 400;
-        return res.end(
-          `service.prerender.cloud can't prerender this page due to user error: ${data.body}`
+        debug(
+          "service.headless-render-api.com returned status 400 request invalid:"
         );
+        res.status(400).send(data.body);
       } else if (data.statusCode === 429) {
         return handleSkip("rate limited due to free tier", next);
       } else {

--- a/source/index.js
+++ b/source/index.js
@@ -31,7 +31,7 @@ require("./lib/got-retries")(got, options, debug);
 
 const vary = require("vary");
 
-// preserve (and send to client) these headers from service.prerender.cloud which originally came from the origin server
+// preserve (and send to client) these headers from service.headless-render-api.com which originally came from the origin server
 const headerWhitelist = [
   "vary",
   "content-type",
@@ -272,8 +272,8 @@ class Prerender {
       });
   }
 
-  // fulfills promise when service.prerender.cloud response is: 2xx, 4xx
-  // rejects promise when request lib errors or service.prerender.cloud response is: 5xx
+  // fulfills promise when service.headless-render-api.com response is: 2xx, 4xx
+  // rejects promise when request lib errors or service.headless-render-api.com response is: 5xx
   _get() {
     const apiRequestUrl = this._createApiRequestUrl();
     const headers = this._createHeaders();
@@ -327,7 +327,7 @@ class Prerender {
 
           if (err.message && err.message.match(/throttle/)) {
             return createResponse(this.req, this.url.requestedUrl, {
-              body: "Error: prerender.cloud client throttled this prerender request due to a recent timeout",
+              body: "Error: headless-render-api.com client throttled this prerender request due to a recent timeout",
               statusCode: 503,
               headers: { "content-type": "text/html" },
             });
@@ -335,7 +335,7 @@ class Prerender {
 
           if (isGotClientTimeout(err))
             return createResponse(this.req, this.url.requestedUrl, {
-              body: "Error: prerender.cloud client timeout (as opposed to prerender.cloud server timeout)",
+              body: "Error: headless-render-api.com client timeout (as opposed to headless-render-api.com server timeout)",
               statusCode: 500,
               headers: { "content-type": "text/html" },
             });
@@ -354,7 +354,7 @@ class Prerender {
       this._writeHttpResponse(req, res, next, data);
 
     if (options.options.afterRenderBlocking) {
-      // preserve original body from origin prerender.cloud so mutations
+      // preserve original body from origin headless-render-api.com so mutations
       // from afterRenderBlocking don't affect concurrentRequestCache
       if (!data.origBodyBeforeAfterRenderBlocking) {
         data.origBodyBeforeAfterRenderBlocking = data.body;

--- a/source/index.js
+++ b/source/index.js
@@ -318,6 +318,13 @@ class Prerender {
               err.response
             );
 
+          if (err.response && is4xxError(err.response.statusCode))
+            return createResponse(
+              this.req,
+              this.url.requestedUrl,
+              err.response
+            );
+
           if (err.message && err.message.match(/throttle/)) {
             return createResponse(this.req, this.url.requestedUrl, {
               body: "Error: prerender.cloud client throttled this prerender request due to a recent timeout",

--- a/source/index.js
+++ b/source/index.js
@@ -382,7 +382,8 @@ class Prerender {
         debug(
           "service.headless-render-api.com returned status 400 request invalid:"
         );
-        res.status(400).send(data.body);
+        res.statusCode = 400;
+        res.send(data.body);
       } else if (data.statusCode === 429) {
         return handleSkip("rate limited due to free tier", next);
       } else {

--- a/source/index.js
+++ b/source/index.js
@@ -511,6 +511,11 @@ class Prerender {
 
     if (options.options.shouldPrerender) {
       return options.options.shouldPrerender(this.req);
+    } else if (options.options.shouldPrerenderAdditionalCheck) {
+      return (
+        options.options.shouldPrerenderAdditionalCheck(this.req) &&
+        this._prerenderableUserAgent()
+      );
     } else {
       return this._prerenderableUserAgent();
     }

--- a/source/lib/options.js
+++ b/source/lib/options.js
@@ -83,6 +83,7 @@ module.exports = class Options {
       "middlewareCacheMaxAge",
       "whitelistQueryParams",
       "shouldPrerender",
+      "shouldPrerenderAdditionalCheck",
       "removeScriptTags",
       "removeTrailingSlash",
       "protocol",

--- a/spec/helpers/helper.js
+++ b/spec/helpers/helper.js
@@ -129,6 +129,7 @@ global.withHttpMiddlewareMocks = function () {
 
       this.next = jasmine.createSpy("nextMiddleware").and.callFake(done);
       this.res.end = jasmine.createSpy("end").and.callFake(done);
+      this.res.send = jasmine.createSpy("send").and.callFake(done);
 
       configureUrlForReq(this.req, options);
     }.bind(this);

--- a/spec/indexSpec.js
+++ b/spec/indexSpec.js
@@ -183,12 +183,14 @@ describe("prerender middleware", function () {
         beforeEach(function (done) {
           this.prerenderServer = nock("https://service.prerender.cloud")
             .get(/.*/)
-            .reply(() => [400, "errmsg"]);
+            .reply(() => [400, "user error"]);
           this.callPrerenderMiddleware(() => done());
         });
 
         it("returns pre-rendered body", function () {
-          expect(this.res.end.calls.mostRecent().args[0]).toMatch(/user error/);
+          expect(this.res.send.calls.mostRecent().args[0]).toMatch(
+            /user error/
+          );
         });
       });
 
@@ -2022,7 +2024,7 @@ describe("prerender middleware", function () {
                 {}
               );
               expect(this.res.end.calls.mostRecent().args[0]).toEqual(
-                "Error: prerender.cloud client timeout (as opposed to prerender.cloud server timeout)"
+                "Error: headless-render-api.com client timeout (as opposed to headless-render-api.com server timeout)"
               );
             });
             itRetries();

--- a/spec/throttleOnTimeoutSpec.js
+++ b/spec/throttleOnTimeoutSpec.js
@@ -97,7 +97,7 @@ describe("timeout causes throttling", function () {
       });
       itBubblesUp(
         503,
-        "Error: prerender.cloud client throttled this prerender request due to a recent timeout"
+        "Error: headless-render-api.com client throttled this prerender request due to a recent timeout"
       );
     });
     describe("with throttling enabled", function () {


### PR DESCRIPTION
Adds `shouldPrerenderAdditionalCheck`. Which runs **in addition** to the default user-agent check. Useful if you have your own conditions.

Example:

```
// time delay
const waitUntil = new Date() + 10000;
prerendercloud.set("shouldPrerenderAdditionalCheck", (req) => {
  return new Date() > waitUntil;
});

// enable flag
let isEnabled = false;
prerendercloud.set("shouldPrerenderAdditionalCheck", (req) => {
  return isEnabled;
});
```