### PR TITLE
Fix scrape redirect, fix null scrape response, add statusCode, headers, ogType to scrape response

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,43 +286,52 @@ Or scrape HTML and take a screenshot, and parse important meta tags (title, h1, 
 
 ```javascript
 const {
-  body,
+  body, // Buffer
   meta: {
     title,
     h1,
     description,
     ogImage,
     ogTitle,
+    ogType,
     ogDescription,
     twitterCard,
   },
-  links,
-  screenshot,
+  links, // Array
+  screenshot, // Buffer
+  statusCode, // number
+  headers, // object of headers
 } = await prerendercloud.scrape("https://example.com", {
   withMetadata: true,
   withScreenshot: true,
+  followRedirects: false,
 });
 
-console.log(body.toString());
-console.log({
-  meta: {
-    title,
-    h1,
-    description,
-    ogImage,
-    ogTitle,
-    ogDescription,
-    twitterCard,
-  },
-  links,
-});
-fs.writeFileSync("body.html", body);
-fs.writeFileSync("screenshot.png", screenshot);
+if (statusCode === 301 || statusCode === 302) {
+  // get the redirect location from headers.location
+  // if instead you'd rather follow redirects, set followRedirects: true
+} else {
+  console.log(body.toString());
+  console.log({
+    meta: {
+      title,
+      h1,
+      description,
+      ogImage,
+      ogTitle,
+      ogDescription,
+      twitterCard,
+    },
+    links,
+  });
+  fs.writeFileSync("body.html", body);
+  fs.writeFileSync("screenshot.png", screenshot);
 
-// links is an array of all the links on the page
-// meta is an object that looks like: { title, h1, description, ogImage, ogTitle, ogDescription, twitterCard }
-// screenshot and body are Buffers (so they can be saved to file)
-// call body.toString() for stringified HTML
+  // links is an array of all the links on the page
+  // meta is an object that looks like: { title, h1, description, ogImage, ogTitle, ogType, ogDescription, twitterCard }
+  // screenshot and body are Buffers (so they can be saved to file)
+  // call body.toString() for stringified HTML
+}
 ```
 
 <a name="prerendering-or-server-side-rendering-with-expressconnectnode-http"></a>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prerendercloud",
-  "version": "1.46.5",
+  "version": "1.47.0",
   "description": "Express middleware for pre-rendering JavaScript single page apps with https://headless-render-api.com (formerly prerender.cloud from 2016 - 2022) for SEO and open graph tags",
   "main": "./distribution/index.js",
   "scripts": {

--- a/source/index.js
+++ b/source/index.js
@@ -803,6 +803,21 @@ const screenshotAndPdf = (action, url, params = {}) => {
       return res.body;
     }
 
+    let shouldReturnRedirect = false;
+    if (
+      !options.options.followRedirect &&
+      (res.statusCode === 302 || res.statusCode === 301)
+    ) {
+      shouldReturnRedirect = true;
+    }
+
+    if (shouldReturnRedirect) {
+      return {
+        statusCode: res.statusCode,
+        headers: res.headers,
+      };
+    }
+
     // scrape always returns an object as opposed to buffer
     // and if the response was not json, then it didn't have
     // options like withScreenshot or withMetadata

--- a/source/index.js
+++ b/source/index.js
@@ -828,7 +828,20 @@ const screenshotAndPdf = (action, url, params = {}) => {
     }
 
     const parsed = JSON.parse(res.body);
+
     Object.keys(parsed).forEach((key) => {
+      if (!parsed[key]) {
+        return;
+      }
+      if (key === "statusCode" && parsed[key]) {
+        parsed[key] = parseInt(parsed[key]);
+        return;
+      }
+      if (key === "headers" && parsed[key]) {
+        parsed[key] = parsed[key];
+        return;
+      }
+
       parsed[key] = Buffer.from(parsed[key], "base64");
       if (key === "meta" || key === "links") {
         parsed[key] = JSON.parse(parsed[key].toString());

--- a/source/index.js
+++ b/source/index.js
@@ -797,6 +797,7 @@ const screenshotAndPdf = (action, url, params = {}) => {
     encoding: null,
     headers,
     retries: options.options.retries,
+    followRedirect: options.options.followRedirect || false,
   }).then((res) => {
     if (action === "pdf" || action === "screenshot") {
       return res.body;
@@ -841,6 +842,7 @@ Prerender.middleware.prerender = function (url, params) {
     encoding: null,
     headers,
     retries: options.options.retries,
+    followRedirect: options.options.followRedirect || false,
   }).then((res) => res.body);
 };
 

--- a/test/scrape.js
+++ b/test/scrape.js
@@ -26,10 +26,23 @@ const prerendercloud = require("../source/index");
     screenshot: screenshot3,
     meta: meta3,
     links: link3,
+    headers: headers3,
+    statusCode: statusCode3,
   } = await prerendercloud.scrape("http://example.com", {
     withScreenshot: true,
     withMetadata: true,
   });
+  if (statusCode3 !== 200) {
+    throw new Error(`Expected statusCode to be 200, but got ${statusCode3}`);
+  } else {
+    console.log("test3 withMetadata statusCode passed");
+  }
+  if (Object.keys(headers3).length === 0) {
+    throw new Error(`Expected headers to be non-empty, but got ${headers3}`);
+  } else {
+    console.log("test3 withMetadata headers passed");
+  }
+
   const expectedLinks = ["https://www.iana.org/domains/example"];
   const expectedMeta = {
     title: "Example Domain",
@@ -38,6 +51,7 @@ const prerendercloud = require("../source/index");
     ogImage: null,
     ogTitle: null,
     ogDescription: null,
+    ogType: null,
     twitterCard: null,
   };
   if (JSON.stringify(link3) !== JSON.stringify(expectedLinks)) {


### PR DESCRIPTION
#### Fixes redirect bug in pre-rendering and scraping:

on the headless-render-api server, follow-redirects is false for pre-rendering and scraping (by default). This means, if a pre-rendered or scraped page redirects, the server will return status code 301/302 and location header as opposed to following it.

This client was misconfigured to follow that redirect instead of respecting the default option of returning the redirect to the client. To change this default behavior to follow redirects instead, for pre-rendering use `prerendercloud.set("followRedirects", (req) => true);` or for scraping use `prerendercloud.scrape(url, { followRedirects: true });

#### Fixes scrape when no body/links/screenshot exist

If the page didn't return a screenshot, links, or meta the base64 field will be empty.



#### adds original server statusCode and header response to scrape response:

So you can see what the original server returned to the headless browser, and for example, decide what to do about a redirect, or debug headers.